### PR TITLE
bump alpine version to 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,7 @@
 FROM alpine:3.19 AS certs
-RUN addgroup -g 10001 user && \
-    adduser -H -D -u 10000 -s /bin/false -G user user && \
-    grep user /etc/passwd > /etc/passwd_user && grep user /etc/group > /etc/group_user
 RUN apk add --no-cache ca-certificates && update-ca-certificates
 
 FROM scratch
 ENTRYPOINT ["/scheduler"]
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=certs /etc/passwd_user /etc/passwd
-COPY --from=certs /etc/group_user /etc/group
 COPY scheduler /
-USER user:user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
-FROM alpine:3.17 AS certs
-RUN apk add --no-cache ca-certificates &&  update-ca-certificates
+FROM alpine:3.19 AS certs
+RUN addgroup -g 10001 user && \
+    adduser -H -D -u 10000 -s /bin/false -G user user && \
+    grep user /etc/passwd > /etc/passwd_user && grep user /etc/group > /etc/group_user
+RUN apk add --no-cache ca-certificates && update-ca-certificates
 
 FROM scratch
 ENTRYPOINT ["/scheduler"]
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-ADD scheduler /
+COPY --from=certs /etc/passwd_user /etc/passwd
+COPY --from=certs /etc/group_user /etc/group
+COPY scheduler /
+USER user:user

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -7,15 +7,9 @@ COPY . .
 RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/app ./cmd/...
 
 FROM alpine:3.19 AS certs
-RUN addgroup -g 10001 user && \
-    adduser -H -D -u 10000 -s /bin/false -G user user && \
-    grep user /etc/passwd > /etc/passwd_user && grep user /etc/group > /etc/group_user
 RUN apk add --no-cache ca-certificates && update-ca-certificates
 
 FROM scratch
 ENTRYPOINT ["/app"]
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=certs /etc/passwd_user /etc/passwd
-COPY --from=certs /etc/group_user /etc/group
 COPY --from=build /usr/local/bin/app /app
-USER user:user

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -6,10 +6,16 @@ RUN go mod download && go mod verify
 COPY . .
 RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/app ./cmd/...
 
-FROM alpine:3.17 AS certs
-RUN apk add --no-cache ca-certificates &&  update-ca-certificates
+FROM alpine:3.19 AS certs
+RUN addgroup -g 10001 user && \
+    adduser -H -D -u 10000 -s /bin/false -G user user && \
+    grep user /etc/passwd > /etc/passwd_user && grep user /etc/group > /etc/group_user
+RUN apk add --no-cache ca-certificates && update-ca-certificates
 
 FROM scratch
 ENTRYPOINT ["/app"]
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=certs /etc/passwd_user /etc/passwd
+COPY --from=certs /etc/group_user /etc/group
 COPY --from=build /usr/local/bin/app /app
+USER user:user


### PR DESCRIPTION
Updates to latest alpine release ~and sets up a normal user so compose-scheduler doesn't run as root inside the container.~
If this change is ok with you would you mind tagging a new release after merging?