### PR TITLE
Update scheduler.go

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -220,7 +220,7 @@ func containerID() (string, error) {
 		return "", fmt.Errorf("detect container ID: %w", err)
 	}
 	id := filepath.Base(strings.TrimSpace(string(data)))
-	if id == "/" {
+	if id == "/" || id == ".." {
 		return "", fmt.Errorf("calculate container ID from %s: %w", string(data), err)
 	}
 


### PR DESCRIPTION
Fix issue when containerID returns `/../..`, so that when it filters the returned string, it identifies containerID `..`, and then fails at the end, bc this is invalid container id

Fixing issue I faced in #6 