### PR TITLE
Print command output to logs

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
     labels:
       - "net.reddec.scheduler.cron=* * * * *"
       - "net.reddec.scheduler.exec=nginx -s reload"
+      - "net.reddec.scheduler.logs=true"
   date:
     image: busybox
     restart: "no"

--- a/scheduler.go
+++ b/scheduler.go
@@ -161,6 +161,14 @@ func (sc *Scheduler) execService(ctx context.Context, task Task) error {
 	}
 	defer attach.Close()
 	io.Copy(log.Writer(), attach.Reader)
+
+	inspect, err := sc.client.ContainerExecInspect(ctx, execID.ID)
+    if err != nil {
+    	return fmt.Errorf("inspect exec for %s: %w", task.Service, err)
+    }
+    if inspect.ExitCode != 0 {
+    	return fmt.Errorf("command returned non-zero code %d", inspect.ExitCode)
+    }
 	return nil
 }
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"strconv"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -219,12 +220,18 @@ func (sc *Scheduler) listTasks(ctx context.Context) ([]Task, error) {
 			}
 			args = cmd
 		}
+
+    	isLoggingEnabled, err := strconv.ParseBool(c.Labels[logsLabel])
+    	if err != nil {
+            isLoggingEnabled = false
+    	}
+
 		ans = append(ans, Task{
 			Container: c.ID,
 			Schedule:  c.Labels[schedulerLabel],
 			Service:   service,
 			Command:   args,
-			logging:   c.Labels[logsLabel] == "true",
+			logging:   isLoggingEnabled,
 		})
 	}
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -220,7 +220,7 @@ func containerID() (string, error) {
 		return "", fmt.Errorf("detect container ID: %w", err)
 	}
 	id := filepath.Base(strings.TrimSpace(string(data)))
-	if id == "/" {
+	if id == "/" || id == ".." {
 		return "", fmt.Errorf("calculate container ID from %s: %w", string(data), err)
 	}
 


### PR DESCRIPTION
I really like that ofelia prints stdout/stderr from the scheduled command directly into docker container logs.
Current change make it work. 
I am not sure if you want to make it opt-in/-out, in case people don't like it. But tbh I don't think that somebody would like not to have that. 

What do you think?