### PR TITLE
feat: support gotify format and notifying only on errors

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '~1.19'
+          go-version: '~1.23'
         id: go
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19 AS certs
+FROM alpine:3.21 AS certs
 RUN apk add --no-cache ca-certificates && update-ca-certificates
 
 FROM scratch

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.19 AS build
+FROM golang:1.23 AS build
 WORKDIR /usr/src/app
 COPY go.mod go.sum ./
 RUN go mod download && go mod verify
@@ -6,7 +6,7 @@ RUN go mod download && go mod verify
 COPY . .
 RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/app ./cmd/...
 
-FROM alpine:3.19 AS certs
+FROM alpine:3.21 AS certs
 RUN apk add --no-cache tzdata ca-certificates && update-ca-certificates
 
 FROM scratch

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Using the same example as above:
 
 ```json
 {
-  "message": "Project: compose-project\nService: web\nContainer: deadbeaf1234\nError: exit code 1\nStarted: 2023-01-20T11:10:39.44006+08:00\nFinished: 2023-01-20T11:10:39.751879+08:00\nSchedule: @daily",
+  "message": "Project: compose-project\nService: web\nContainer: deadbeaf1234\nError: status code: exit code 1, logs: 2024-12-23T18:25:23.115935476Z 2024/12/23 18:25:23 Error \nStarted: 2006-01-02T15:04:05Z07:00\nFinished: 2006-01-02T15:04:05Z07:00\nSchedule: @daily",
   "title": "Service web failed"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Docker-Compose scheduler
 
 Simple and lightweight service which can execute `docker compose run ...` services from the same file based on cron
-expression. 
+expression.
 
 Features:
 
@@ -39,7 +39,7 @@ Supports two modes:
 
 ## Usage
 
-```
+```text
 Application Options:
       --project=              Docker compose project, will be automatically detected if not set [$PROJECT]
 
@@ -50,6 +50,8 @@ HTTP notification:
       --notify.method=        HTTP method (default: POST) [$NOTIFY_METHOD]
       --notify.timeout=       Request timeout (default: 30s) [$NOTIFY_TIMEOUT]
       --notify.authorization= Authorization header value [$NOTIFY_AUTHORIZATION]
+      --notify.gotify=        Use Gotify format [$NOTIFY_GOTIFY]
+      --notify.onlyfailures=  Only send notifications for failed jobs [$NOTIFY_ONLY_FAILURES]
 
 Help Options:
   -h, --help                  Show this help message
@@ -61,6 +63,8 @@ Scheduler will send notifications after each job if `NOTIFY_URL` env variable or
 notification is a simple HTTP request.
 HTTP method, attempts number, and interval between attempts can be configured.
 Authorization via `Authorization` header also supported.
+If `NOTIFY_GOTIFY` is set the gotify notification format is used.
+When `NOTIFY_ONLY_FAILURES` is set, notifications will be sent only when the job fails.
 
 Scheduler will stop retries if at least one of the following criteria met:
 
@@ -73,7 +77,7 @@ Outgoing custom headers:
 - `User-Agent: scheduler/<version>`, where `<version>` is build version
 - `Authorization: <value>` (if set)
 
-Payload:
+Normal Payload:
 
 ```json
 {
@@ -88,5 +92,15 @@ Payload:
 }
 ```
 
-> field `error` exists only if `failed == true`
+> Note: the field `error` exists only if `failed == true`
 
+Gotify Payload:
+
+Using the same example as above:
+
+```json
+{
+  "message": "Project: compose-project\nService: web\nContainer: deadbeaf1234\nError: exit code 1\nStarted: 2023-01-20T11:10:39.44006+08:00\nFinished: 2023-01-20T11:10:39.751879+08:00\nSchedule: @daily",
+  "title": "Service web failed"
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/reddec/compose-scheduler
 
-go 1.19
+go 1.23
 
 require (
 	github.com/Microsoft/go-winio v0.6.0 // indirect


### PR DESCRIPTION
This PR adds support for sending notifications in the [gotify](https://gotify.net/) format by setting the `gotify/NOTIFY_GOTIFY` flags.
I've also added another flag that limits notifications to failures only (`onlyfailures/NOTIFY_ONLY_FAILURES`)

I took the opportunity to bump the alpine and go versions.